### PR TITLE
Add Streamlit Excel dashboard app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# brightonheng
+# Excel Dashboard Builder
+
+This simple Streamlit application lets you upload an Excel file and turn it into an interactive visualization and dashboard.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the application with Streamlit:
+
+```bash
+streamlit run excel_dashboard.py
+```
+
+Upload an `.xlsx` or `.xls` file to explore the data, create charts and view summary statistics.

--- a/excel_dashboard.py
+++ b/excel_dashboard.py
@@ -1,0 +1,45 @@
+import streamlit as st
+import pandas as pd
+import plotly.express as px
+
+
+def main() -> None:
+    st.title("Excel Dashboard Builder")
+    st.write("Upload an Excel file to explore the data and build charts.")
+
+    uploaded_file = st.file_uploader("Upload Excel file", type=["xlsx", "xls"])
+    if not uploaded_file:
+        return
+
+    df = pd.read_excel(uploaded_file)
+    st.subheader("Data preview")
+    st.dataframe(df.head())
+
+    if df.empty:
+        st.warning("The uploaded file contains no data.")
+        return
+
+    chart_type = st.selectbox(
+        "Chart type", ["Line", "Bar", "Scatter", "Area"], index=0
+    )
+    x_axis = st.selectbox("X-axis", options=df.columns)
+    numeric_columns = df.select_dtypes(include="number").columns
+    y_axis = st.selectbox("Y-axis", options=numeric_columns)
+
+    if st.button("Create chart"):
+        if chart_type == "Line":
+            fig = px.line(df, x=x_axis, y=y_axis)
+        elif chart_type == "Bar":
+            fig = px.bar(df, x=x_axis, y=y_axis)
+        elif chart_type == "Scatter":
+            fig = px.scatter(df, x=x_axis, y=y_axis)
+        else:
+            fig = px.area(df, x=x_axis, y=y_axis)
+        st.plotly_chart(fig, use_container_width=True)
+
+        st.subheader("Summary statistics")
+        st.write(df.describe())
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+streamlit
+pandas
+plotly
+openpyxl


### PR DESCRIPTION
## Summary
- create Streamlit app to turn Excel files into interactive charts and summary statistics
- document setup and usage

## Testing
- `python -m py_compile excel_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_689c9713dafc832a80da96e56b0738bd